### PR TITLE
Added Activation Arguments

### DIFF
--- a/toast_windows.go
+++ b/toast_windows.go
@@ -53,11 +53,20 @@ func WithIconRaw(raw []byte) NotificationOption {
 // WithActivationType
 //
 // The type of notification level action (like Action)
-// func WithActivationType(activationType string) NotificationOption {
-// 	return func(n *notification) {
-// 		n.ActivationType = activationType
-// 	}
-// }
+func WithActivationType(activationType string) NotificationOption {
+	return func(n *notification) {
+		n.ActivationType = activationType
+	}
+}
+
+// WithActivationArguments
+//
+// // The activation/action arguments (invoked when the user clicks the notification)
+func WithActivationArguments(activationArguments string) NotificationOption {
+	return func(n *notification) {
+		n.ActivationArguments = activationArguments
+	}
+}
 
 // WithProtocolAction
 //


### PR DESCRIPTION
In one of my projects, I needed to be able to open the browser when the notification was clicked on, without the use of buttons.
This was not possible in the current form even though it is an value already part of the code and that gets put into the xml.

Thus I have added `WithActivationArguments `and re-added the commented out `WithActivationType`